### PR TITLE
docs: organize & delete duplicate Documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,16 @@ npm run type-check
 ## **Documentation**
 
 - [API Contract](docs/API_CONTRACT.md)
-- [Architecture](docs/TECH_DESIGN.md)
+- [Architecture & Tech Design](docs/TECH_DESIGN.md)
+- [Feature Brief](docs/FEATURE_BRIEF.md)
 - [Testing Strategy](docs/TESTING_STRATEGY.md)
 - [Security Guidelines](docs/SECURITY.md)
 - [Database Setup](docs/SETUP_DATABASE.md)
 - [UX Guidelines](docs/UX_GUIDELINES.md)
+- [User Stories](docs/USER_STORIES.md)
 - [Performance Notes](docs/PERFORMANCE_NOTES.md)
 - [Future Considerations](docs/FUTURE_CONSIDERATIONS.md)
+- [Contributing](docs/CONTRIBUTING.md)
 
 ---
 
@@ -175,21 +178,6 @@ npm run type-check
 * **E2E Tests:** `Cypress`
 * **Accessibility:** `jest-axe`, `cypress-axe`
 * **Visual UI Testing:** Storybook Test Runner
-
-## **Documentation**
-
-- [API Contract](docs/API_CONTRACT.md)
-- [Architecture](docs/TECH_DESIGN.md)
-- [Contributing](docs/CONTRIBUTING.md)
-- [Database Setup](docs/SETUP_DATABASE.md)
-- [Feature Brief](docs/FEATURE_BRIEF.md)
-- [Future Considerations](docs/FUTURE_CONSIDERATIONS.md)
-- [Performance Notes](docs/PERFORMANCE_NOTES.md)
-- [Security Guidelines](docs/SECURITY.md)
-- [Tech Design](docs/TECH_DESIGN.md)
-- [Testing Strategy](docs/TESTING_STRATEGY.md)
-- [User Stories](docs/USER_STORIES.md)
-- [UX Guidelines](docs/UX_GUIDELINES.md)
 
 
 ## **Contributing**


### PR DESCRIPTION
# Summary

This pull is updating the README and organizing the links listed under the Documentation header by removing duplicates.


## **Changes Implemented**

- [ ] Feature 1
- [ ] Feature 2
- [ ] Bug Fixes
- [ ] Tests Updated
- [x] Documentation Updated

- Removed duplicate Documentation subheader and links
  - API Contract
  - Database Setup
  - Future Considerations
  - Performance Notes
  - Security Guidelines
  - Testing Strategy
  - UX Guidelines
- Combined Architecture and Tech Design links into  "Architecture & Tech Design"


# Reasoning

These changes were made to remove duplicate information and organize the documentation links under one subheader.

The Architecture link redirects to the Tech Design markdown file and was thus combined into "Architecture & Tech Design"

# Acceptance Criteria

- [x] Links redirect to its matching markdown file


# Screenshots
Before 
![Screenshot 2025-05-21 at 11 47 21 PM](https://github.com/user-attachments/assets/41a894ad-d943-4cca-aa02-b453e1294180)
<br>
After
![Screenshot 2025-05-22 at 12 02 33 AM](https://github.com/user-attachments/assets/df1e020a-a7db-4ada-8211-6a5a39b3f381)



